### PR TITLE
Add login endpoint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+README.md text

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const app = express();
-const PORT = 3000;
+const PORT = process.env.PORT || 3000;
+const HOST = process.env.HOST || '0.0.0.0';
 
 app.use(express.json());
 
@@ -8,7 +9,9 @@ app.get('/', (req, res) => {
   res.send('Hello Welcome to our app ');
 });
 
-const users = [{ id: 1, name: 'John' }];
+// In-memory user store for demo purposes
+// Each user has an id, name and password
+const users = [{ id: 1, name: 'John', password: 'secret' }];
 
 app.get('/users', (req, res) => {
   res.json(users);
@@ -20,6 +23,24 @@ app.post('/users', (req, res) => {
   res.status(201).json(newUser);
 });
 
-app.listen(PORT, () => {
-  console.log(`🚀  Server listening at http://localhost:${PORT}`);
+// Login route
+// Expects JSON body with "name" and "password" fields
+// Responds with a success message when credentials match
+// otherwise returns 401 Unauthorized
+app.post('/login', (req, res) => {
+  const { name, password } = req.body;
+  const user = users.find(u => u.name === name && u.password === password);
+  if (user) {
+    res.json({ message: 'Login successful' });
+  } else {
+    res.status(401).json({ error: 'Invalid credentials' });
+  }
 });
+
+if (require.main === module) {
+  app.listen(PORT, HOST, () => {
+    console.log(`🚀  Server listening at http://localhost:${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test.js"
   },
   "keywords": [],
   "author": "",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,45 @@
+const http = require('http');
+const assert = require('assert');
+const app = require('./index');
+
+const server = app.listen(0, () => {
+  const { port } = server.address();
+  const data = JSON.stringify({ name: 'John', password: 'secret' });
+
+  const opts = {
+    hostname: 'localhost',
+    port,
+    path: '/login',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(data)
+    }
+  };
+
+  const req = http.request(opts, (res) => {
+    let body = '';
+    res.on('data', chunk => body += chunk);
+    res.on('end', () => {
+      try {
+        assert.strictEqual(res.statusCode, 200);
+        const json = JSON.parse(body);
+        assert.strictEqual(json.message, 'Login successful');
+        console.log('Login test passed');
+        server.close();
+      } catch (err) {
+        console.error('Test failed');
+        console.error(err);
+        server.close(() => process.exit(1));
+      }
+    });
+  });
+
+  req.on('error', (err) => {
+    console.error(err);
+    server.close(() => process.exit(1));
+  });
+
+  req.write(data);
+  req.end();
+});


### PR DESCRIPTION
## Summary
- implement a `/login` API endpoint
- expose server on `0.0.0.0` so it can be reached on a LAN
- allow host/port override via environment variables
- export the app for testing and add a simple login test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c62ac9a38833185671bc1ce05a693