### PR TITLE
Refactor API structure with user model

### DIFF
--- a/api/controllers/authController.js
+++ b/api/controllers/authController.js
@@ -1,0 +1,35 @@
+const User = require('../models/User');
+
+exports.signup = async (req, res) => {
+  const { name, password } = req.body;
+  if (!name || !password) {
+    return res.status(400).json({ message: 'Name and password are required' });
+  }
+  try {
+    const existing = await User.findOne({ name });
+    if (existing) {
+      return res.status(409).json({ message: 'User already exists' });
+    }
+    const user = new User({ name, password });
+    await user.save();
+    res.status(201).json({ message: 'Signup successful' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+exports.login = async (req, res) => {
+  const { name, password } = req.body;
+  if (!name || !password) {
+    return res.status(400).json({ message: 'Name and password are required' });
+  }
+  try {
+    const user = await User.findOne({ name, password });
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    res.json({ message: 'Login successful' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+};

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+// Define schema
+const userSchema = new mongoose.Schema({
+  name: { type: String, required: true, unique: true },
+  password: { type: String, required: true }
+});
+
+// Export model
+module.exports = mongoose.model('User', userSchema);

--- a/api/routes/auth.js
+++ b/api/routes/auth.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const authController = require('../controllers/authController');
+
+router.post('/signup', authController.signup);
+router.post('/login', authController.login);
+
+module.exports = router;

--- a/index.js
+++ b/index.js
@@ -1,49 +1,21 @@
 const express = require('express');
+const mongoose = require('mongoose');
+const authRoutes = require('./api/routes/auth');
+
 const app = express();
 const PORT = 3000;
 
+mongoose
+  .connect(process.env.MONGO_URI || 'mongodb://localhost:27017/myapp')
+  .then(() => console.log('MongoDB connected'))
+  .catch((err) => console.error('MongoDB connection error:', err));
+
 app.use(express.json());
+
+app.use('/api', authRoutes);
 
 app.get('/', (req, res) => {
   res.send('Hello Welcome to our app ');
-});
-
-const users = [];
-
-app.post('/signup', (req, res) => {
-  const { username, password } = req.body;
-  if (!username || !password) {
-    console.log('Signup attempt with missing credentials');
-    return res
-      .status(400)
-      .json({ message: 'Username and password are required' });
-  }
-
-  const existing = users.find((u) => u.username === username);
-  if (existing) {
-    console.log(`Signup failed: user ${username} already exists`);
-    return res.status(409).json({ message: 'User already exists' });
-  }
-
-  const newUser = { id: Date.now(), username, password };
-  users.push(newUser);
-  console.log(`User signed up: ${username}`);
-  res.status(201).json({ message: 'Signup successful' });
-});
-
-app.post('/login', (req, res) => {
-  const { username, password } = req.body;
-  const user = users.find(
-    (u) => u.username === username && u.password === password
-  );
-
-  if (user) {
-    console.log(`User logged in: ${username}`);
-    return res.json({ message: 'Login successful' });
-  }
-
-  console.log(`Failed login attempt: ${username}`);
-  res.status(401).json({ message: 'Invalid credentials' });
 });
 
 app.listen(PORT, () => {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "mongoose": "^8.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add User mongoose model
- organize auth routes and controllers under api folder
- connect to MongoDB and mount auth routes in server

## Testing
- `npm install mongoose` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mongoose)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b54b9cbf8c8331aa233073e7a75cea