### PR TITLE
feat: add social login support

### DIFF
--- a/api/controllers/authController.js
+++ b/api/controllers/authController.js
@@ -1,5 +1,9 @@
 const Customer = require('../models/Customer');
 const Maid = require('../models/Maid');
+const { OAuth2Client } = require('google-auth-library');
+const fetch = require('node-fetch');
+
+const googleClient = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 
 exports.signup = async (req, res) => {
   const { role } = req.params;
@@ -42,5 +46,50 @@ exports.login = async (req, res) => {
     res.json({ message: 'Login successful' });
   } catch (err) {
     res.status(500).json({ message: 'Server error' });
+  }
+};
+
+exports.socialLogin = async (req, res) => {
+  const { role } = req.params;
+  const { provider, token } = req.body;
+  if (!provider || !token) {
+    return res.status(400).json({ message: 'Provider and token are required' });
+  }
+  const Model = role === 'customer' ? Customer : role === 'maid' ? Maid : null;
+  if (!Model) {
+    return res.status(400).json({ message: 'Invalid role' });
+  }
+
+  try {
+    let email;
+    if (provider === 'google') {
+      const ticket = await googleClient.verifyIdToken({
+        idToken: token,
+        audience: process.env.GOOGLE_CLIENT_ID,
+      });
+      const payload = ticket.getPayload();
+      email = payload && payload.email;
+    } else if (provider === 'facebook') {
+      const response = await fetch(
+        `https://graph.facebook.com/me?fields=email&access_token=${token}`
+      );
+      const data = await response.json();
+      email = data.email;
+    } else {
+      return res.status(400).json({ message: 'Unsupported provider' });
+    }
+
+    if (!email) {
+      return res.status(400).json({ message: 'Unable to retrieve email from provider' });
+    }
+
+    let user = await Model.findOne({ email });
+    if (!user) {
+      user = new Model({ email });
+      await user.save();
+    }
+    res.json({ message: 'Login successful', user });
+  } catch (err) {
+    res.status(401).json({ message: 'Invalid social token' });
   }
 };

--- a/api/models/Customer.js
+++ b/api/models/Customer.js
@@ -2,7 +2,8 @@ const mongoose = require('mongoose');
 
 const customerSchema = new mongoose.Schema({
   email: { type: String, required: true, unique: true },
-  password: { type: String, required: true }
+  // Password is optional to support social login accounts
+  password: { type: String }
 });
 
 module.exports = mongoose.model('Customer', customerSchema);

--- a/api/models/Maid.js
+++ b/api/models/Maid.js
@@ -2,7 +2,8 @@ const mongoose = require('mongoose');
 
 const maidSchema = new mongoose.Schema({
   email: { type: String, required: true, unique: true },
-  password: { type: String, required: true }
+  // Password is optional to support social login accounts
+  password: { type: String }
 });
 
 module.exports = mongoose.model('Maid', maidSchema);

--- a/api/routes/auth.js
+++ b/api/routes/auth.js
@@ -4,5 +4,6 @@ const authController = require('../controllers/authController');
 
 router.post('/signup/:role', authController.signup);
 router.post('/login/:role', authController.login);
+router.post('/social-login/:role', authController.socialLogin);
 
 module.exports = router;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "bcrypt": "^6.0.0",
     "express": "^5.1.0",
-    "mongoose": "^8.0.0"
+    "google-auth-library": "^9.0.0",
+    "mongoose": "^8.0.0",
+    "node-fetch": "^2.6.7"
   }
 }


### PR DESCRIPTION
## Summary
- support Google/Facebook social login
- allow optional passwords in user models
- add dependencies for social auth

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b91c91fdb083318b027c480fb94848